### PR TITLE
fix OpenID when not yet logged in

### DIFF
--- a/app/controllers/open_id_provider_controller.rb
+++ b/app/controllers/open_id_provider_controller.rb
@@ -175,12 +175,30 @@ class OpenIdProviderController < ApplicationController
   end
 
   def redirect_to_login_page
-    # Extract only the basic url parameters on non-GET requests
-    if request.get?
-      url = url_for(params)
-    else
-      url = url_for(:controller => params[:controller], :action => params[:action], :id => params[:id], :project_id => params[:project_id])
-    end
+    permitted = params.permit(
+	:"openid.assoc_handle",
+	:"openid.ax.mode",
+	:"openid.ax.required",
+	:"openid.ax.type.ext0",
+	:"openid.ax.type.ext1",
+	:"openid.ax.type.ext2",
+	:"openid.ax.type.ext3",
+	:"openid.ax.type.ext4",
+	:"openid.ax.type.ext5",
+	:"openid.ax.type.ext6",
+	:"openid.claimed_id",
+	:"openid.identity",
+	:"openid.mode",
+	:"openid.ns",
+	:"openid.ns.ax",
+	:"openid.ns.sreg",
+	:"openid.realm",
+	:"openid.return_to",
+	:"openid.sreg.required",
+	:"controller",
+	:"action"
+	)
+    url = url_for(permitted)
     redirect_to :controller => "account", :action => "login", :back_url => url
   end
 


### PR DESCRIPTION
Before this patch, there are problems with using redmine as OpenID provider when the user is not yet logged in on redmine:

- For GET, the parameters are not "permitted" as required by rails >= 5.
- For POST, most OpenID parameters are dropped.

Permit all valid OpenID parameters, for both GET and POST, to allow ruby to hash the parameters, and to pass all OpenID parameters without omission.

This should

- Fix OpenID login using GET
- Fix redirecting back to the service trying to log in for OpenID using POST.
- Both GET and POST should work identically now.

Background:
We encountered two practical problems with OpenID login, when the user is not yet logged in on redmine (the OpenID provider):
- When logging into gerrit.osmocom.org using osmocom.org OpenID, the redmine login would not complete the OpenID service, and would not redirect back to gerrit's original view. (That is because the OpenID parameters were mostly stripped during OpenID POST)
- Also we are internally developing a webapp to use osmocom.org login, where the python library used for OpenID apparently uses GET instead of POST; this completely failed before this patch.
 
This patch wants to fix both of these problems.

Explanation from
https://stackoverflow.com/questions/46029084/rails-unable-to-convert-unpermitted-parameters-to-hash

   "In Rails 5, ActionController::Parameters no longer inherits from Hash,
   in an attempt to discourage people from using Hash-related methods on
   the request parameters without explicitly filtering them.
   As part of this pull request[1], which was backported into Rails 5.1 and
   partially into Rails 5.0, an exception is raised if you try to call to_h
   on the parameters object without calling permit."
   [1] https://github.com/rails/rails/pull/28734